### PR TITLE
Fix syntax for OBO 1.4 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script:
   - wget http://build.berkeleybop.org/userContent/owltools/ontology-release-runner -O bin/ontology-release-runner
   - wget http://build.berkeleybop.org/userContent/owltools/owltools-runner-all.jar -O bin/owltools-runner-all.jar
   - wget http://build.berkeleybop.org/userContent/owltools/owltools-oort-all.jar -O bin/owltools-oort-all.jar
-  - wget http://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot -O bin/robot
-  - wget http://build.berkeleybop.org/job/robot/lastSuccessfulBuild/artifact/bin/robot.jar -O bin/robot.jar
+  - wget https://github.com/ontodev/robot/releases/download/v1.4.0/robot.jar -O bin/robot.jar
+  - wget https://raw.githubusercontent.com/ontodev/robot/master/bin/robot -O bin/robot
   - wget --no-check-certificate https://raw.githubusercontent.com/cmungall/pattern2owl/master/apply-pattern.py -O bin/apply-pattern.py
   - chmod +x bin/*
   

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -149,7 +149,7 @@ VCHECKS = equivalent-classes trailing-whitespace owldef-self-reference xref-synt
 # run all violation checks
 VQUERIES = $(foreach V,$(VCHECKS),$(SPARQLDIR)/$V-violation.sparql)
 sparql_test: $(SRC)
-	robot verify -i $< --queries $(VQUERIES) -O reports/
+	$(ROBOT) verify -i $< --queries $(VQUERIES) -O reports/
 
 # ----------------------------------------
 # Sparql queries: Reports
@@ -158,4 +158,4 @@ sparql_test: $(SRC)
 REPORTS = basic-report class-count-by-prefix edges xrefs obsoletes synonyms
 REPORT_ARGS = $(foreach V,$(REPORTS),-s $(SPARQLDIR)/$V.sparql reports/$V.tsv)
 all_reports: $(SRC)
-	robot query -f tsv -i $< $(REPORT_ARGS)
+	$(ROBOT) query -f tsv -i $< $(REPORT_ARGS)


### PR DESCRIPTION
Hi!

I'm working with @cmungall on improving the syntax and semantics of the OBO format (the draft of the version 1.4 is available [here](http://owlcollab.github.io/oboformat/doc/obo-syntax.html)). This PR fixes duplicate `is_metadata_tag` clauses that were using integers instead of booleans.
Other than that `mco.obo` is 1.4 compliant :tada: 